### PR TITLE
Reorganize to show potential folder structure

### DIFF
--- a/src/Item.js
+++ b/src/Item.js
@@ -1,10 +1,9 @@
-import React, { useState, useEffect } from 'react';
-import { db } from './lib/firebase';
-import estimates from './lib/estimates';
 import { differenceInDays, fromUnixTime } from 'date-fns';
-import { Modal } from '@material-ui/core';
-import StyledModalLayout, { StyledModalBtn } from './StyledModal';
 import { useSnackbar } from 'notistack';
+import React, { useEffect, useState } from 'react';
+import { Modal } from './components';
+import estimates from './lib/estimates';
+import { db } from './lib/firebase';
 
 function Item({ userToken, item }) {
   const { itemName, id, purchaseDates, purchaseEstimates = [] } = item;
@@ -123,23 +122,19 @@ function Item({ userToken, item }) {
       </button>
       {/* // [delete-item] 2. Create a button modal that will render when user tries to delete item */}
       <Modal
-        open={openModal}
+        cancelLabel="Cancel"
+        confirmLabel="Confirm"
         onClose={handleCloseModal}
-        aria-labelledby="delete-modal-title"
-      >
-        <StyledModalLayout>
-          <h1 id="delete-modal-title">
+        onConfirm={handleDelete}
+        open={openModal}
+        title={
+          <>
             Are you sure you want to delete <span>{itemName}</span> from your
             list?
-          </h1>
-          <StyledModalBtn type="button" onClick={handleCloseModal}>
-            Cancel
-          </StyledModalBtn>
-          <StyledModalBtn type="button" onClick={handleDelete}>
-            Yes
-          </StyledModalBtn>
-        </StyledModalLayout>
-      </Modal>
+          </>
+        }
+        titleId="delete-modal-title"
+      />
     </li>
   );
 }

--- a/src/Item.js
+++ b/src/Item.js
@@ -123,7 +123,7 @@ function Item({ userToken, item }) {
       {/* // [delete-item] 2. Create a button modal that will render when user tries to delete item */}
       <Modal
         cancelLabel="Cancel"
-        confirmLabel="Confirm"
+        confirmLabel="Yes"
         onClose={handleCloseModal}
         onConfirm={handleDelete}
         open={openModal}

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,0 +1,31 @@
+import { Modal as MuiModal } from '@material-ui/core';
+import React from 'react';
+import { StyledModalBtn, StyledModalLayout } from './elements';
+
+const Modal = ({
+  cancelLabel,
+  children,
+  confirmLabel,
+  onClose,
+  onConfirm,
+  open,
+  title,
+  titleId,
+}) => {
+  return (
+    <MuiModal open={open} onClose={onClose} aria-labelledby={titleId}>
+      <StyledModalLayout>
+        <h1 id={titleId}>{title}</h1>
+        {children}
+        <StyledModalBtn type="button" onClick={onClose}>
+          {cancelLabel}
+        </StyledModalBtn>
+        <StyledModalBtn type="button" onClick={onConfirm}>
+          {confirmLabel}
+        </StyledModalBtn>
+      </StyledModalLayout>
+    </MuiModal>
+  );
+};
+
+export default Modal;

--- a/src/components/Modal/elements.js
+++ b/src/components/Modal/elements.js
@@ -1,0 +1,44 @@
+import styled from 'styled-components';
+
+// These elements are really just associated with the DeleteModal component
+// No need to make these available everywhere
+// You could have a more Global elements file, as well,
+// as well as use the `GlobalStyles` component from styled-components
+export const StyledModalBtn = styled.button`
+  display: inline-block;
+  padding: 5px;
+  margin: 0.5rem 1rem;
+  width: 6rem;
+  background: transparent;
+  color: black;
+  text-align: center;
+  cursor: pointer;
+  background: lightgray;
+  justify-content: center;
+  border: none;
+  &:hover {
+    background: darkgray;
+  }
+`;
+
+export const StyledModalLayout = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 70%;
+  background-color: white;
+  padding: 6rem;
+  border-radius: 5px;
+  box-shadow: 0 3rem 5rem rgba(0, 0, 0, 0.3);
+  z-index: 10;
+  max-width: 250px;
+  font-size: 15px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  span {
+    text-decoration: underline;
+  }
+`;

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,0 +1,1 @@
+export { default } from './Modal';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,4 @@
+import Modal from './Modal';
+
+// Then you can export all of the components from here
+export { Modal };


### PR DESCRIPTION
## Description

This is an example of what a component's folder structure could look like. I created a `components` directory. Inside, there is a `Modal` directory, that houses all of the code for the Modal component. One file has all of the styled components for the Modal. Then, there is one main index file in the `components` directory that will export all of the components.

`rosa chopin tried` is a good test token.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|   | :sparkles: New feature     |
|  ✓   | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |


## Testing Steps / QA Criteria

`rosa chopin tried` is a good token to use. The delete functionality should work the same as on Karan and Abby's branch.

