### PR TITLE
A11y for ShareToken form

### DIFF
--- a/src/components/ShareToken/ShareToken.js
+++ b/src/components/ShareToken/ShareToken.js
@@ -40,7 +40,12 @@ const ShareToken = (props) => {
       <p>Join an existing shopping list by entering a three word token.</p>
       <StyledForm id="shareToken" onSubmit={onSubmitHandler}>
         <label htmlFor="shareToken">Share token</label>
-        <TextField variant="outlined" onChange={onChangeHandler} required />
+        <TextField
+          id="shareToken"
+          variant="outlined"
+          onChange={onChangeHandler}
+          required
+        />
         <Button
           color="secondary"
           size="small"


### PR DESCRIPTION


## Description
1. Share token input was not associated with its label.
2. Added the matching ID to the label


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before
![image](https://user-images.githubusercontent.com/10378331/119978955-e2b1ff80-bf7f-11eb-8a5c-2448590c99e4.png)




### After
![image](https://user-images.githubusercontent.com/10378331/119978978-ee9dc180-bf7f-11eb-98e8-61f1b59280be.png)



