### PR TITLE
bugfix: reorganize globalStyles so Styled Components can access theme

### DIFF
--- a/src/components/General/globalStyles.js
+++ b/src/components/General/globalStyles.js
@@ -1,35 +1,7 @@
 import { createGlobalStyle } from 'styled-components';
 import { createMuiTheme } from '@material-ui/core/styles';
 
-// --- STYLED_COMPONENTS ---
-
-const GlobalStyle = createGlobalStyle`
-  li {
-    list-style: none;
-  }
-  html, 
-  body, 
-  #root {
-    height: 100%;
-  }
-  body{
-    margin: 0;
-  }
-  .App {
-    flex: 0 0 50vh;
-    width: 100%;
-    margin: 4.5em;
-    padding: 3.5em;
-    background-color: ${theme.palette.background.paper};
-    border-radius: 12px;
-    box-shadow: 0px 3px 6px rgba(0, 0, 0, 0.1),
-                0px 4px 8px rgba(0, 0, 0, 0.08),
-                0px 1px 12px rgba(0, 0, 0, 0.04); 
-    text-align: center; 
-  }
-`;
-
-export default GlobalStyle;
+// --- THEME FONTS AND COLORS ---
 
 export const hFont = 'Maven Pro';
 
@@ -110,3 +82,33 @@ export const theme = createMuiTheme({
     },
   },
 });
+
+// --- STYLED_COMPONENTS ---
+
+const GlobalStyle = createGlobalStyle`
+  li {
+    list-style: none;
+  }
+  html, 
+  body, 
+  #root {
+    height: 100%;
+  }
+  body{
+    margin: 0;
+  }
+  .App {
+    flex: 0 0 50vh;
+    width: 100%;
+    margin: 4.5em;
+    padding: 3.5em;
+    background-color: ${theme.palette.background.paper};
+    border-radius: 12px;
+    box-shadow: 0px 3px 6px rgba(0, 0, 0, 0.1),
+                0px 4px 8px rgba(0, 0, 0, 0.08),
+                0px 1px 12px rgba(0, 0, 0, 0.04); 
+    text-align: center; 
+  }
+`;
+
+export default GlobalStyle;


### PR DESCRIPTION
## Description
App was crashing because MUI Theme in `globalStyles` couldn't be accessed before it was initialized. Order of this file must be 1) define theme fonts and colors 2) initialize MUI theme 3) define styled components, in order for everything to scope properly


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before
![image](https://user-images.githubusercontent.com/58532369/120032233-e2d5ed80-bfc7-11eb-95e4-34b3dd93a7b2.png)
![image](https://user-images.githubusercontent.com/58532369/120032288-f6815400-bfc7-11eb-9e45-f4e03e60532c.png)


### After
![image](https://user-images.githubusercontent.com/58532369/120032366-144eb900-bfc8-11eb-90e7-ac71c2a053a2.png)

